### PR TITLE
feat: add `double_xtreme` stadium

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -19,6 +19,7 @@ per-file-ignores =
     src/analytics/advanced_stats.py:E501
     src/analytics/advanced_stats_combined.py:E501
     src/analytics/advanced_stats_drop_attack.py:E501
+    src/analytics/advanced_stats_double_xtreme.py:E501
     # Allow long lines in embedded JavaScript/HTML code
     src/plots/meta_landscape.py:E501
     # Allow whitespace in embedded HTML templates

--- a/docs/bey.html
+++ b/docs/bey.html
@@ -84,6 +84,7 @@
                     <select id="arenaPlotSelect" class="arena-plot-select">
                         <option value="xtreme" selected>Xtreme Stadium (Season/Global)</option>
                         <option value="drop_attack">Drop Attack Beystadium</option>
+                        <option value="double_xtreme">Double Xtreme Stadium</option>
                         <option value="combined">Combined/Global (All Matches)</option>
                     </select>
                 </div>
@@ -450,6 +451,13 @@ async function loadData() {
                 const advancedData = parseCSV(advancedText);
                 allLeaderboardData = advancedData;
                 leaderboardData = findLeaderboardEntry(advancedData, beyName);
+            } else if (currentArena === 'double_xtreme') {
+                // Try Double Xtreme advanced leaderboard
+                const advancedResponse = await fetch(DATA_PATHS.ADVANCED_LEADERBOARD_DOUBLE_XTREME_CSV);
+                const advancedText = await advancedResponse.text();
+                const advancedData = parseCSV(advancedText);
+                allLeaderboardData = advancedData;
+                leaderboardData = findLeaderboardEntry(advancedData, beyName);
             } else if (currentArena === 'combined') {
                 // Combined arena - no advanced stats, use standard leaderboard
                 throw new Error('Use arena-specific leaderboard');
@@ -473,8 +481,11 @@ async function loadData() {
         // Build arena lookup map (match_id string -> normalized arena)
         allMatchesRaw.forEach(m => {
             const raw = m.arena || 'Xtreme';
-            // Normalize 'DropAttack' variant to 'Drop Attack'
-            matchArenaMap[m.MatchID] = raw === 'DropAttack' ? 'Drop Attack' : raw;
+            // Normalize arena variants to canonical names
+            let normalized = raw;
+            if (raw === 'DropAttack') normalized = 'Drop Attack';
+            else if (raw === 'DoubleXtreme' || raw === 'double_xtreme') normalized = 'Double Xtreme';
+            matchArenaMap[m.MatchID] = normalized;
         });
         const allMatches = allMatchesRaw.map(m => ({
             matchId: parseInt(m.MatchID.slice(1).replace(/^0+/, ''), 10),
@@ -1916,6 +1927,7 @@ function renderScoreDistribution() {
     // Filter matches by current arena
     const arenaLabel = currentArena === 'xtreme' ? 'Xtreme' :
                        currentArena === 'drop_attack' ? 'Drop Attack' :
+                       currentArena === 'double_xtreme' ? 'Double Xtreme' :
                        currentArena === 'combined' ? null : currentArena;
 
     const filteredMatches = arenaLabel
@@ -2069,6 +2081,7 @@ function renderFinishTypeDistribution() {
     // Arena filter label
     const arenaLabel = currentArena === 'xtreme' ? 'Xtreme' :
                        currentArena === 'drop_attack' ? 'Drop Attack' :
+                       currentArena === 'double_xtreme' ? 'Double Xtreme' :
                        currentArena === 'combined' ? null : currentArena;
 
     // Filter rounds data to matches involving this bey, then by arena

--- a/docs/data-paths.js
+++ b/docs/data-paths.js
@@ -43,12 +43,14 @@ const DATA_PATHS = Object.freeze({
     LEADERBOARD_V1_CSV:                   'data/leaderboard/leaderboard_v1.csv',
     LEADERBOARD_V2_CSV:                   'data/leaderboard/leaderboard_v2.csv',
     LEADERBOARD_XTREME_CSV:               'data/leaderboard/leaderboard_xtreme.csv',
-    LEADERBOARD_DROP_ATTACK_CSV:          'data/leaderboard/leaderboard_drop_attack.csv',
-    LEADERBOARD_COMBINED_CSV:             'data/leaderboard/leaderboard_combined.csv',
-    LEADERBOARD_ALL_ARENAS_CSV:           'data/leaderboard/leaderboard_all_arenas.csv',
-    ADVANCED_LEADERBOARD_CSV:             'data/leaderboard/advanced_leaderboard.csv',
-    ADVANCED_LEADERBOARD_DROP_ATTACK_CSV: 'data/leaderboard/advanced_leaderboard_drop_attack.csv',
-    ADVANCED_LEADERBOARD_COMBINED_CSV:    'data/leaderboard/advanced_leaderboard_combined.csv',
+    LEADERBOARD_DROP_ATTACK_CSV:              'data/leaderboard/leaderboard_drop_attack.csv',
+    LEADERBOARD_DOUBLE_XTREME_CSV:            'data/leaderboard/leaderboard_double_xtreme.csv',
+    LEADERBOARD_COMBINED_CSV:                 'data/leaderboard/leaderboard_combined.csv',
+    LEADERBOARD_ALL_ARENAS_CSV:               'data/leaderboard/leaderboard_all_arenas.csv',
+    ADVANCED_LEADERBOARD_CSV:                 'data/leaderboard/advanced_leaderboard.csv',
+    ADVANCED_LEADERBOARD_DROP_ATTACK_CSV:     'data/leaderboard/advanced_leaderboard_drop_attack.csv',
+    ADVANCED_LEADERBOARD_DOUBLE_XTREME_CSV:   'data/leaderboard/advanced_leaderboard_double_xtreme.csv',
+    ADVANCED_LEADERBOARD_COMBINED_CSV:        'data/leaderboard/advanced_leaderboard_combined.csv',
 
     // -----------------------------------------------------------------------
     // Analytics

--- a/docs/leaderboard.html
+++ b/docs/leaderboard.html
@@ -64,6 +64,7 @@
                 <select id="arenaSelector" class="arena-select">
                     <option value="xtreme" selected>Xtreme Stadium (Season/Global)</option>
                     <option value="drop_attack">Drop Attack Beystadium</option>
+                    <option value="double_xtreme">Double Xtreme Stadium</option>
                     <option value="combined">Combined/Global (All Matches)</option>
                     <option value="all_arenas">All Arenas (Comparison)</option>
                 </select>

--- a/docs/leaderboard.js
+++ b/docs/leaderboard.js
@@ -41,7 +41,11 @@ const ALL_ARENAS_HEADER_NAMES = {
     'ELO_DropAttack': 'Drop Attack ELO',
     'Matches_DropAttack': 'Drop Attack Matches',
     'Wins_DropAttack': 'Drop Attack Wins',
-    'Winrate_DropAttack': 'Drop Attack Win%'
+    'Winrate_DropAttack': 'Drop Attack Win%',
+    'ELO_DoubleXtreme': 'Double Xtreme ELO',
+    'Matches_DoubleXtreme': 'Double Xtreme Matches',
+    'Wins_DoubleXtreme': 'Double Xtreme Wins',
+    'Winrate_DoubleXtreme': 'Double Xtreme Win%'
 };
 
 // Full descriptions for legend with detailed explanations
@@ -194,6 +198,11 @@ function loadLeaderboard(isAdvanced = false, matchIndex = null) {
             csvPath = isAdvanced
                 ? DATA_PATHS.ADVANCED_LEADERBOARD_DROP_ATTACK_CSV
                 : DATA_PATHS.LEADERBOARD_DROP_ATTACK_CSV;
+        } else if (currentArena === "double_xtreme") {
+            // Load Double Xtreme arena leaderboard (advanced if requested)
+            csvPath = isAdvanced
+                ? DATA_PATHS.ADVANCED_LEADERBOARD_DOUBLE_XTREME_CSV
+                : DATA_PATHS.LEADERBOARD_DOUBLE_XTREME_CSV;
         } else {
             // Load current leaderboard (standard or advanced for Xtreme/default)
             csvPath = isAdvanced
@@ -258,10 +267,12 @@ function renderTable(headers, rows) {
 
         // Add arena data attribute for comparison view visual grouping
         if (currentArena === "all_arenas") {
-            if (h.includes("Xtreme")) {
+            if (h.includes("Xtreme") && !h.includes("Double")) {
                 th.setAttribute("data-arena", "xtreme");
             } else if (h.includes("DropAttack")) {
                 th.setAttribute("data-arena", "drop_attack");
+            } else if (h.includes("DoubleXtreme")) {
+                th.setAttribute("data-arena", "double_xtreme");
             } else if (h.includes("Global")) {
                 th.setAttribute("data-arena", "combined");
             }
@@ -292,10 +303,12 @@ function renderTable(headers, rows) {
             
             // Add arena data attribute for comparison view visual grouping
             if (currentArena === "all_arenas") {
-                if (h.includes("Xtreme")) {
+                if (h.includes("Xtreme") && !h.includes("Double")) {
                     td.setAttribute("data-arena", "xtreme");
                 } else if (h.includes("DropAttack")) {
                     td.setAttribute("data-arena", "drop_attack");
+                } else if (h.includes("DoubleXtreme")) {
+                    td.setAttribute("data-arena", "double_xtreme");
                 } else if (h.includes("Global")) {
                     td.setAttribute("data-arena", "combined");
                 }

--- a/docs/quick-entry.html
+++ b/docs/quick-entry.html
@@ -79,6 +79,7 @@
                 <select id="arenaSelect" class="control-select">
                     <option value="Xtreme" selected>Xtreme Stadium</option>
                     <option value="Drop Attack">Drop Attack Beystadium</option>
+                    <option value="Double Xtreme">Double Xtreme Stadium</option>
                     <option value="Combined">Combined/Global</option>
                 </select>
             </div>

--- a/docs/quick-entry.js
+++ b/docs/quick-entry.js
@@ -1623,7 +1623,7 @@ function renderSeasonFields(matchIndex, match) {
                 <select class="season-field-select" onchange="updateArena(${matchIndex}, this.value)" data-match="${matchIndex}">
                     <option value="Xtreme" ${arena === 'Xtreme' ? 'selected' : ''}>⚡ Xtreme Stadium</option>
                     <option value="DropAttack" ${arena === 'DropAttack' ? 'selected' : ''}>🎯 Drop Attack Beystadium</option>
-                    <option value="DoubleXtreme" ${arena === 'DoubleXtreme' ? 'selected' : ''}>⚡⚡ Double Xtreme Stadium</option>
+                    <option value="DoubleXtreme" ${arena === 'DoubleXtreme' ? 'selected' : ''}>💢 Double Xtreme Stadium</option>
                 </select>
             </div>
             <div class="season-field-group ${needsSeasonId ? '' : 'field-disabled'}">

--- a/docs/quick-entry.js
+++ b/docs/quick-entry.js
@@ -1623,6 +1623,7 @@ function renderSeasonFields(matchIndex, match) {
                 <select class="season-field-select" onchange="updateArena(${matchIndex}, this.value)" data-match="${matchIndex}">
                     <option value="Xtreme" ${arena === 'Xtreme' ? 'selected' : ''}>⚡ Xtreme Stadium</option>
                     <option value="DropAttack" ${arena === 'DropAttack' ? 'selected' : ''}>🎯 Drop Attack Beystadium</option>
+                    <option value="DoubleXtreme" ${arena === 'DoubleXtreme' ? 'selected' : ''}>⚡⚡ Double Xtreme Stadium</option>
                 </select>
             </div>
             <div class="season-field-group ${needsSeasonId ? '' : 'field-disabled'}">
@@ -1901,6 +1902,7 @@ function renderArenaSelect(selectedArena, matchIndex) {
                 data-match="${matchIndex}">
             <option value="Xtreme" ${selectedArena === 'Xtreme' ? 'selected' : ''}>⚡ Xtreme</option>
             <option value="DropAttack" ${selectedArena === 'DropAttack' ? 'selected' : ''}>🎯 Drop Attack</option>
+            <option value="DoubleXtreme" ${selectedArena === 'DoubleXtreme' ? 'selected' : ''}>⚡⚡ Double Xtreme</option>
         </select>
     `;
 }

--- a/docs/stadium-stats.html
+++ b/docs/stadium-stats.html
@@ -602,7 +602,7 @@ document.addEventListener('DOMContentLoaded', loadStadiumData);
 }
 
 .stadium-description {
-    color: var(--text-muted);
+    color: var(--text-light);
     max-width: 800px;
     margin: 10px auto;
 }
@@ -620,9 +620,9 @@ document.addEventListener('DOMContentLoaded', loadStadiumData);
 
 .stadium-button {
     padding: 12px 24px;
-    border: 2px solid var(--border-color);
-    background: var(--card-bg);
-    color: var(--text-primary);
+    border: 2px solid var(--border);
+    background: var(--card);
+    color: var(--text);
     border-radius: 8px;
     cursor: pointer;
     transition: all 0.3s ease;
@@ -630,14 +630,18 @@ document.addEventListener('DOMContentLoaded', loadStadiumData);
 }
 
 .stadium-button:hover {
-    background: var(--hover-bg);
+    background: var(--bg-subtle);
+    border-color: var(--accent);
     transform: translateY(-2px);
 }
 
 .stadium-button.active {
-    background: var(--primary-color);
+    background: var(--accent);
     color: white;
-    border-color: var(--primary-color);
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-hover-subtle), 0 4px 12px rgba(0,0,0,0.15);
+    transform: translateY(-2px);
+    font-weight: 700;
 }
 
 .stadium-overview-grid,
@@ -650,8 +654,8 @@ document.addEventListener('DOMContentLoaded', loadStadiumData);
 }
 
 .stat-card {
-    background: var(--card-bg);
-    border: 1px solid var(--border-color);
+    background: var(--card);
+    border: 1px solid var(--border);
     border-radius: 8px;
     padding: 20px;
     text-align: center;
@@ -659,14 +663,14 @@ document.addEventListener('DOMContentLoaded', loadStadiumData);
 
 .stat-label {
     font-size: 0.9em;
-    color: var(--text-muted);
+    color: var(--text-light);
     margin-bottom: 8px;
 }
 
 .stat-value {
     font-size: 1.8em;
     font-weight: bold;
-    color: var(--primary-color);
+    color: var(--accent);
 }
 
 .finish-chart-container {
@@ -684,32 +688,32 @@ document.addEventListener('DOMContentLoaded', loadStadiumData);
 
 .performers-column h4 {
     margin-bottom: 15px;
-    color: var(--text-primary);
+    color: var(--text);
 }
 
 .performer-card {
-    background: var(--card-bg);
-    border: 1px solid var(--border-color);
+    background: var(--card);
+    border: 1px solid var(--border);
     border-radius: 8px;
     padding: 15px;
     margin-bottom: 10px;
 }
 
 .performer-card.struggling {
-    border-left: 3px solid var(--danger-color);
+    border-left: 3px solid #ef4444;
 }
 
 .performer-name {
     font-weight: bold;
     margin-bottom: 8px;
-    color: var(--text-primary);
+    color: var(--text);
 }
 
 .performer-stats {
     display: flex;
     gap: 10px;
     font-size: 0.9em;
-    color: var(--text-muted);
+    color: var(--text-light);
 }
 
 .comparison-grid {
@@ -720,15 +724,15 @@ document.addEventListener('DOMContentLoaded', loadStadiumData);
 }
 
 .comparison-card {
-    background: var(--card-bg);
-    border: 1px solid var(--border-color);
+    background: var(--card);
+    border: 1px solid var(--border);
     border-radius: 8px;
     padding: 20px;
 }
 
 .comparison-card h4 {
     margin-bottom: 15px;
-    color: var(--primary-color);
+    color: var(--accent);
 }
 
 .comparison-section {
@@ -754,17 +758,17 @@ document.addEventListener('DOMContentLoaded', loadStadiumData);
 .data-table td {
     padding: 12px;
     text-align: left;
-    border-bottom: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--border);
 }
 
 .data-table th {
-    background: var(--card-bg);
+    background: var(--card);
     font-weight: bold;
-    color: var(--text-primary);
+    color: var(--text);
 }
 
 .data-table tbody tr:hover {
-    background: var(--hover-bg);
+    background: var(--bg-subtle);
 }
 
 section {
@@ -772,10 +776,10 @@ section {
 }
 
 section h3 {
-    color: var(--text-primary);
+    color: var(--text);
     margin-bottom: 20px;
     padding-bottom: 10px;
-    border-bottom: 2px solid var(--border-color);
+    border-bottom: 2px solid var(--border);
 }
 
 .loading-placeholder,
@@ -783,15 +787,15 @@ section h3 {
 .error-message {
     padding: 20px;
     text-align: center;
-    color: var(--text-muted);
-    background: var(--card-bg);
-    border: 1px solid var(--border-color);
+    color: var(--text-light);
+    background: var(--card);
+    border: 1px solid var(--border);
     border-radius: 8px;
 }
 
 .error-message {
-    color: var(--danger-color);
-    border-color: var(--danger-color);
+    color: #ef4444;
+    border-color: #ef4444;
 }
 
 .help-text {
@@ -799,8 +803,8 @@ section h3 {
     align-items: center;
     gap: 8px;
     padding: 10px;
-    background: var(--card-bg);
-    border-left: 3px solid var(--primary-color);
+    background: var(--card);
+    border-left: 3px solid var(--accent);
     margin: 10px 0;
     border-radius: 4px;
 }

--- a/docs/stadium-stats.html
+++ b/docs/stadium-stats.html
@@ -700,7 +700,7 @@ document.addEventListener('DOMContentLoaded', loadStadiumData);
 }
 
 .performer-card.struggling {
-    border-left: 3px solid #ef4444;
+    border-left: 3px solid var(--danger, #ef4444);
 }
 
 .performer-name {
@@ -794,8 +794,8 @@ section h3 {
 }
 
 .error-message {
-    color: #ef4444;
-    border-color: #ef4444;
+    color: var(--danger, #ef4444);
+    border-color: var(--danger, #ef4444);
 }
 
 .help-text {

--- a/src/analytics/advanced_stats_double_xtreme.py
+++ b/src/analytics/advanced_stats_double_xtreme.py
@@ -1,0 +1,400 @@
+# advanced_stats.py
+import csv
+import statistics
+from collections import defaultdict
+import os
+
+import sys
+import os as _os
+_root = _os.path.dirname(
+    _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))))
+if _root not in sys.path:
+    sys.path.insert(0, _root)
+del _os, _root
+from src.config.paths import ELO_HISTORY_CSV, ADVANCED_LEADERBOARD_DOUBLE_XTREME_CSV  # noqa: E402
+
+os.system("")
+
+# Farben
+RESET = "\033[0m"
+BOLD = "\033[1m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+CYAN = "\033[36m"
+
+
+HISTORY_FILE = ELO_HISTORY_CSV
+ADVANCED_FILE = ADVANCED_LEADERBOARD_DOUBLE_XTREME_CSV
+
+# --- Power Index Weights ---
+POWER_INDEX_WEIGHTS = {
+    "elo": 0.40,           # Base skill rating
+    "winrate": 0.25,       # Consistent performance
+    "trend": 0.15,         # Current form/momentum
+    "activity": 0.10,      # Match engagement
+    "consistency": 0.10    # Reliability (inverse of volatility)
+}
+
+
+def calculate_power_index(elo, winrate, trend, matches, volatility,
+                          max_elo, min_elo, max_trend, min_trend,
+                          max_matches, max_volatility):
+    """
+    Calculate the Power Index (Meta Score) for a Beyblade.
+
+    The Power Index is a composite score (0-100) that combines multiple factors:
+    - ELO rating (40%): Base skill level
+    - Winrate (25%): Consistent performance percentage
+    - ELO Trend (15%): Recent form/momentum
+    - Activity (10%): Match engagement level
+    - Consistency (10%): Performance reliability (inverse of volatility)
+
+    Args:
+        elo: Current ELO rating
+        winrate: Win rate as decimal (0.0-1.0)
+        trend: ELO trend (sum of all ELO changes)
+        matches: Number of matches played
+        volatility: Standard deviation of ELO changes
+        max_elo: Maximum ELO in the dataset (for normalization)
+        min_elo: Minimum ELO in the dataset (for normalization)
+        max_trend: Maximum trend value in the dataset
+        min_trend: Minimum trend value in the dataset
+        max_matches: Maximum matches played by any Bey
+        max_volatility: Maximum volatility in the dataset
+
+    Returns:
+        float: Power Index score from 0 to 100
+    """
+    # Normalize ELO (0-1 scale)
+    elo_range = max_elo - min_elo if max_elo != min_elo else 1
+    normalized_elo = (elo - min_elo) / elo_range
+
+    # Winrate is already 0-1
+    normalized_winrate = winrate
+
+    # Normalize trend (handle negative values with a shift to 0-1 scale)
+    trend_range = max_trend - min_trend if max_trend != min_trend else 1
+    normalized_trend = (trend - min_trend) / trend_range
+
+    # Normalize activity (matches played)
+    normalized_activity = matches / max_matches if max_matches > 0 else 0
+
+    # Normalize consistency (inverse of volatility - lower volatility = better)
+    # Use 1 - (vol / max_vol) so lower volatility gives higher score
+    normalized_consistency = 1 - (volatility / max_volatility) if max_volatility > 0 else 1
+
+    # Calculate weighted Power Index
+    power_index = (
+        POWER_INDEX_WEIGHTS["elo"] * normalized_elo
+        + POWER_INDEX_WEIGHTS["winrate"] * normalized_winrate
+        + POWER_INDEX_WEIGHTS["trend"] * normalized_trend
+        + POWER_INDEX_WEIGHTS["activity"] * normalized_activity
+        + POWER_INDEX_WEIGHTS["consistency"] * normalized_consistency
+    )
+
+    # Scale to 0-100
+    return round(power_index * 100, 1)
+
+
+def calculate_credibility_score(matches, opponent_elos, volatility, max_matches, max_volatility):
+    """
+    Calculate the Credibility Score (Ranking Confidence) for a Beyblade.
+
+    The Credibility Score represents how trustworthy a Bey's current ELO rating is.
+    It combines multiple factors to assess rating reliability:
+    - Match count: More matches → higher credibility
+    - Opponent ELO diversity: Facing a wide range of opponents → higher confidence
+    - ELO volatility: Large fluctuations → lower credibility (unstable performance)
+
+    Args:
+        matches: Number of matches played
+        opponent_elos: List of opponent ELO ratings faced
+        volatility: Standard deviation of ELO changes (performance consistency)
+        max_matches: Maximum matches played by any Bey (for normalization)
+        max_volatility: Maximum volatility in the dataset (for normalization)
+
+    Returns:
+        tuple: (credibility_score, credibility_label)
+            - credibility_score: float from 0.0 to 1.0
+            - credibility_label: str, one of "Low", "Medium", "High"
+    """
+    # Minimum thresholds for credibility
+    MIN_MATCHES_FOR_HIGH = 15  # Need at least 15 matches for high confidence
+    MIN_MATCHES_FOR_MEDIUM = 6  # Need at least 6 matches for medium confidence
+
+    # Weight factors for credibility calculation
+    MATCH_COUNT_WEIGHT = 0.50  # Match experience is most important
+    DIVERSITY_WEIGHT = 0.30    # Opponent diversity
+    STABILITY_WEIGHT = 0.20    # Performance consistency (inverse of volatility)
+
+    # 1. Match Count Factor (0-1 scale)
+    # Uses sigmoid-like curve to give credit for early matches but plateau after sufficient data
+    if matches == 0:
+        match_factor = 0.0
+    else:
+        # Normalize with diminishing returns
+        # Full credit at max_matches, 50% at MIN_MATCHES_FOR_HIGH
+        match_factor = min(1.0, matches / max(max_matches, 1))
+        # Apply sqrt to give more credit to early matches
+        match_factor = match_factor ** 0.7
+
+    # 2. Opponent Diversity Factor (0-1 scale)
+    # Higher standard deviation of opponent ELOs = faced more diverse competition
+    if len(opponent_elos) <= 1:
+        diversity_factor = 0.0
+    else:
+        elo_stddev = statistics.stdev(opponent_elos)
+        # Typical ELO std dev range: 0-100 (wider range = more diverse opponents)
+        # Normalize: 0 = no diversity, 50+ = high diversity
+        diversity_factor = min(1.0, elo_stddev / 50.0)
+
+    # 3. Stability Factor (0-1 scale)
+    # Lower volatility = more stable = higher credibility
+    if max_volatility > 0 and volatility >= 0:
+        # Inverse: high volatility = low stability
+        stability_factor = 1.0 - min(1.0, volatility / max_volatility)
+    else:
+        stability_factor = 1.0  # If no volatility data, assume stable
+
+    # Calculate weighted credibility score
+    credibility_score = (
+        MATCH_COUNT_WEIGHT * match_factor +
+        DIVERSITY_WEIGHT * diversity_factor +
+        STABILITY_WEIGHT * stability_factor
+    )
+
+    # Clamp to 0.0-1.0 range
+    credibility_score = max(0.0, min(1.0, credibility_score))
+
+    # Determine categorical label based on thresholds
+    if matches < MIN_MATCHES_FOR_MEDIUM:
+        # Not enough matches for reliable rating
+        credibility_label = "Low"
+    elif matches < MIN_MATCHES_FOR_HIGH or credibility_score < 0.5:
+        # Some matches but still building reliability
+        credibility_label = "Medium"
+    elif credibility_score >= 0.7:
+        # Well-established rating with good stability and diversity
+        credibility_label = "High"
+    else:
+        # Between thresholds
+        credibility_label = "Medium"
+
+    return round(credibility_score, 3), credibility_label
+
+
+# --- Datenstrukturen ---
+stats = defaultdict(lambda: {
+    "rank": 0,
+    "matches": 0,
+    "wins": 0,
+    "losses": 0,
+    "points_for": 0,
+    "points_against": 0,
+    "elo_deltas": [],
+    "last_elo": 1000,  # letzter PostELO
+    "upset_wins": 0,
+    "upset_losses": 0,
+    "opponent_elos": []  # Track opponent ELOs for credibility calculation
+})
+
+# --- CSV einlesen und Stats sammeln ---
+with open(HISTORY_FILE, newline="", encoding="utf-8") as f:
+    reader = csv.DictReader(f)
+    matches = sorted(reader, key=lambda m: m["Date"])
+    for row in matches:
+        # Only process Double Xtreme arena matches for Double Xtreme advanced statistics
+        elo_arena_updated = row.get("elo_arena_updated", "Xtreme")
+        if elo_arena_updated != "Double Xtreme":
+            continue
+
+        a, b = row["BeyA"], row["BeyB"]
+        pre_a, pre_b = float(row["PreA"]), float(row["PreB"])
+        post_a, post_b = float(row["PostA"]), float(row["PostB"])
+        score_a, score_b = int(row["ScoreA"]), int(row["ScoreB"])
+        total = score_a + score_b
+        if total == 0:
+            continue
+
+        # Statistiken updaten
+        for bey, pre, post, score_self, score_opp, opponent_pre in [
+            (a, pre_a, post_a, score_a, score_b, pre_b),
+            (b, pre_b, post_b, score_b, score_a, pre_a)
+        ]:
+            s = stats[bey]
+            s["matches"] += 1
+            s["points_for"] += score_self
+            s["points_against"] += score_opp
+            delta = post - pre
+            s["elo_deltas"].append(delta)
+            s["last_elo"] = post
+            s["opponent_elos"].append(opponent_pre)  # Track opponent ELO for credibility
+
+            # Win / Loss
+            if score_self > score_opp:
+                s["wins"] += 1
+            else:
+                s["losses"] += 1
+
+            # Upset-Win / Upset-Loss
+            if score_self > score_opp and pre < opponent_pre:
+                s["upset_wins"] += 1
+            if score_self < score_opp and pre > opponent_pre:
+                s["upset_losses"] += 1
+
+# --- Advanced Stats berechnen (Phase 1: Compute intermediate values) ---
+intermediate_data = []
+sorted_stats = sorted(stats.items(), key=lambda x: -x[1]["last_elo"])
+for bey, s in sorted_stats:
+    match_count = s["matches"]
+    wins = s["wins"]
+    losses = s["losses"]
+    points_for = s["points_for"]
+    points_against = s["points_against"]
+    delta_sum = sum(s["elo_deltas"])
+    last_elo = s["last_elo"]
+    # Volatilität
+    volatility = statistics.stdev(s["elo_deltas"]) if len(s["elo_deltas"]) > 1 else 0.0
+    # Avg ΔELO
+    avg_delta = sum(abs(d) for d in s["elo_deltas"]) / match_count if match_count > 0 else 0.0
+    # Max/Min ΔELO
+    max_delta = max(s["elo_deltas"]) if s["elo_deltas"] else 0.0
+    min_delta = min(s["elo_deltas"]) if s["elo_deltas"] else 0.0
+    # Winrate
+    winrate = wins / match_count if match_count > 0 else 0.0
+    # Average Punktedifferenz
+    avg_point_diff = (points_for - points_against) / match_count if match_count > 0 else 0.0
+    # ELO-Trend
+    elo_trend = delta_sum
+
+    intermediate_data.append({
+        "bey": bey,
+        "elo": last_elo,
+        "matches": match_count,
+        "wins": wins,
+        "losses": losses,
+        "winrate": winrate,
+        "points_for": points_for,
+        "points_against": points_against,
+        "avg_point_diff": avg_point_diff,
+        "volatility": volatility,
+        "avg_delta": avg_delta,
+        "max_delta": max_delta,
+        "min_delta": min_delta,
+        "upset_wins": s["upset_wins"],
+        "upset_losses": s["upset_losses"],
+        "elo_trend": elo_trend,
+        "opponent_elos": s["opponent_elos"]  # For credibility calculation
+    })
+
+# --- Phase 2: Calculate normalization parameters for Power Index ---
+all_elos = [d["elo"] for d in intermediate_data]
+all_trends = [d["elo_trend"] for d in intermediate_data]
+all_matches = [d["matches"] for d in intermediate_data]
+all_volatilities = [d["volatility"] for d in intermediate_data]
+
+max_elo = max(all_elos) if all_elos else 1000
+min_elo = min(all_elos) if all_elos else 1000
+max_trend = max(all_trends) if all_trends else 0
+min_trend = min(all_trends) if all_trends else 0
+max_matches = max(all_matches) if all_matches else 1
+max_volatility = max(all_volatilities) if all_volatilities else 1
+
+# --- Phase 3: Calculate Power Index and Credibility Score, build final data ---
+advanced_data = []
+for d in intermediate_data:
+    power_index = calculate_power_index(
+        elo=d["elo"],
+        winrate=d["winrate"],
+        trend=d["elo_trend"],
+        matches=d["matches"],
+        volatility=d["volatility"],
+        max_elo=max_elo,
+        min_elo=min_elo,
+        max_trend=max_trend,
+        min_trend=min_trend,
+        max_matches=max_matches,
+        max_volatility=max_volatility
+    )
+
+    # Calculate credibility score
+    credibility_score, credibility_label = calculate_credibility_score(
+        matches=d["matches"],
+        opponent_elos=d["opponent_elos"],
+        volatility=d["volatility"],
+        max_matches=max_matches,
+        max_volatility=max_volatility
+    )
+
+    advanced_data.append({
+        "bey": d["bey"],
+        "elo": round(d["elo"]),
+        "matches": d["matches"],
+        "wins": d["wins"],
+        "losses": d["losses"],
+        "winrate": f"{d['winrate'] * 100:.1f}%",
+        "points_for": d["points_for"],
+        "points_against": d["points_against"],
+        "avg_point_diff": round(d["avg_point_diff"], 2),
+        "volatility": round(d["volatility"], 2),
+        "avg_delta": round(d["avg_delta"], 2),
+        "max_delta": round(d["max_delta"], 2),
+        "min_delta": round(d["min_delta"], 2),
+        "upset_wins": d["upset_wins"],
+        "upset_losses": d["upset_losses"],
+        "elo_trend": round(d["elo_trend"], 2),
+        "power_index": power_index,
+        "credibility_score": credibility_score,
+        "credibility_label": credibility_label
+    })
+
+# --- Phase 4: Sort by ELO and assign ranks ---
+advanced_data_sorted = sorted(advanced_data, key=lambda x: -x["elo"])
+for rank, d in enumerate(advanced_data_sorted, start=1):
+    d["rank"] = rank
+
+# --- CSV speichern (nach Power Index sortiert) ---
+header = [
+    "Platz", "Bey", "ELO", "PowerIndex", "Matches", "Wins", "Losses", "Winrate",
+    "PointsFor", "PointsAgainst", "AvgPointDiff", "Volatility",
+    "AvgΔELO", "MaxΔELO", "MinΔELO", "UpsetWins", "UpsetLosses", "ELOTrend",
+    "CredibilityScore", "CredibilityLabel"
+]
+
+with open(ADVANCED_FILE, "w", newline="", encoding="utf-8") as f:
+    writer = csv.writer(f)
+    writer.writerow(header)
+    for d in advanced_data_sorted:
+        writer.writerow([
+            d["rank"], d["bey"], d["elo"], d["power_index"], d["matches"],
+            d["wins"], d["losses"], d["winrate"], d["points_for"],
+            d["points_against"], d["avg_point_diff"], d["volatility"],
+            d["avg_delta"], d["max_delta"], d["min_delta"],
+            d["upset_wins"], d["upset_losses"], d["elo_trend"],
+            d["credibility_score"], d["credibility_label"]
+        ])
+
+# No need to copy to docs folder since ADVANCED_FILE already points to docs/data
+
+print(f"{GREEN} Advanced Leaderboard erstellt: {ADVANCED_FILE}")
+
+
+# | Spalte            | Beschreibung                                                                                                                        |
+# | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+# | **Bey**           | Name des Beyblades.                                                                                                                 |
+# | **ELO**           | Aktuelle ELO nach allen bisherigen Matches (letzter PostELO-Wert). Zeigt die Gesamtstärke des Bey im Turnierverlauf.                |
+# | **Matches**       | Anzahl der gespielten Matches.                                                                                                      |
+# | **Wins**          | Anzahl der gewonnenen Matches.                                                                                                      |
+# | **Losses**        | Anzahl der verlorenen Matches.                                                                                                      |
+# | **Winrate**       | Prozentsatz der gewonnenen Matches (`Wins / Matches`). Zeigt die allgemeine Erfolgsquote.                                           |
+# | **PointsFor**     | Summe aller Punkte, die der Bey über alle Matches erzielt hat.                                                                      |
+# | **PointsAgainst** | Summe aller Punkte, die der Bey gegen sich kassiert hat.                                                                            |
+# | **AvgPointDiff**  | Durchschnittliche Punktedifferenz pro Match (`PointsFor − PointsAgainst / Matches`). Zeigt, wie klar ein Bey gewinnt oder verliert. |
+# | **Volatility**    | Standardabweichung der ELO-Änderungen pro Match. Misst, wie stark die Leistung von Match zu Match schwankt.                         |
+# | **AvgΔELO**       | Durchschnittlicher Betrag der ELO-Änderung pro Match. Zeigt, wie stark ein Match typischerweise die Bewertung verändert.            |
+# | **MaxΔELO**       | Größte einzelne ELO-Zunahme in einem Match. Zeigt den stärksten Match-Erfolg.                                                       |
+# | **MinΔELO**       | Größte einzelne ELO-Abnahme in einem Match. Zeigt die größte Niederlage.                                                            |
+# | **UpsetWins**     | Anzahl der Siege gegen Gegner, die vor dem Match eine höhere ELO hatten. Zeigt „Überraschungssiege“.                                |
+# | **UpsetLosses**   | Anzahl der Niederlagen gegen Gegner, die vor dem Match eine niedrigere ELO hatten. Zeigt unerwartete Niederlagen.                   |
+# | **ELOTrend**      | Gesamte ELO-Änderung über alle Matches (`sum(PostELO-PreELO)`). Zeigt, ob der Bey insgesamt stärker oder schwächer geworden ist.    |
+# | **PowerIndex**    | Composite score (0-100) combining ELO (40%), Winrate (25%), Trend (15%), Activity (10%), and Consistency (10%).                     |

--- a/src/analytics/stadium_stats.py
+++ b/src/analytics/stadium_stats.py
@@ -58,7 +58,10 @@ STADIUM_ALIASES = {
     "Drop Attack": "Drop Attack Beystadium",
     "DropAttack": "Drop Attack Beystadium",
     "drop_attack": "Drop Attack Beystadium",
-    "xtreme": "Xtreme Stadium"
+    "xtreme": "Xtreme Stadium",
+    "DoubleXtreme": "Double Xtreme Stadium",
+    "Double Xtreme": "Double Xtreme Stadium",
+    "double_xtreme": "Double Xtreme Stadium",
 }
 
 

--- a/src/config/paths.py
+++ b/src/config/paths.py
@@ -97,10 +97,12 @@ LEADERBOARD_V1_CSV = os.path.join(LEADERBOARD_DIR, "leaderboard_v1.csv")
 LEADERBOARD_V2_CSV = os.path.join(LEADERBOARD_DIR, "leaderboard_v2.csv")
 ADVANCED_LEADERBOARD_CSV = os.path.join(LEADERBOARD_DIR, "advanced_leaderboard.csv")
 ADVANCED_LEADERBOARD_DROP_ATTACK_CSV = os.path.join(LEADERBOARD_DIR, "advanced_leaderboard_drop_attack.csv")
+ADVANCED_LEADERBOARD_DOUBLE_XTREME_CSV = os.path.join(LEADERBOARD_DIR, "advanced_leaderboard_double_xtreme.csv")
 ADVANCED_LEADERBOARD_COMBINED_CSV = os.path.join(LEADERBOARD_DIR, "advanced_leaderboard_combined.csv")
 LEADERBOARD_ALL_ARENAS_CSV = os.path.join(LEADERBOARD_DIR, "leaderboard_all_arenas.csv")
 LEADERBOARD_COMBINED_CSV = os.path.join(LEADERBOARD_DIR, "leaderboard_combined.csv")
 LEADERBOARD_DROP_ATTACK_CSV = os.path.join(LEADERBOARD_DIR, "leaderboard_drop_attack.csv")
+LEADERBOARD_DOUBLE_XTREME_CSV = os.path.join(LEADERBOARD_DIR, "leaderboard_double_xtreme.csv")
 PRIVATE_LEADERBOARD_CSV = os.path.join(LEADERBOARD_DIR, "private_leaderboard.csv")
 
 # ---------------------------------------------------------------------------

--- a/src/elo/archived/beyblade_elo_v2.py
+++ b/src/elo/archived/beyblade_elo_v2.py
@@ -82,9 +82,10 @@ OVERKILL_WEIGHT = 0.25
 # Arena constants
 ARENA_XTREME = "Xtreme"
 ARENA_DROP_ATTACK = "Drop Attack"
+ARENA_DOUBLE_XTREME = "Double Xtreme"
 ARENA_COMBINED = "Combined"  # Tracks all matches from all arenas
-SUPPORTED_ARENAS = [ARENA_XTREME, ARENA_DROP_ATTACK]
-ALL_ARENAS = [ARENA_XTREME, ARENA_DROP_ATTACK, ARENA_COMBINED]  # Including combined
+SUPPORTED_ARENAS = [ARENA_XTREME, ARENA_DROP_ATTACK, ARENA_DOUBLE_XTREME]
+ALL_ARENAS = [ARENA_XTREME, ARENA_DROP_ATTACK, ARENA_DOUBLE_XTREME, ARENA_COMBINED]  # Including combined
 
 # ------------ Arena normalization ------------
 
@@ -101,6 +102,10 @@ def normalize_arena_name(arena):
         "Drop Attack": ARENA_DROP_ATTACK,
         "DropAttack": ARENA_DROP_ATTACK,
         "drop_attack": ARENA_DROP_ATTACK,
+        "double xtreme": ARENA_DOUBLE_XTREME,
+        "Double Xtreme": ARENA_DOUBLE_XTREME,
+        "DoubleXtreme": ARENA_DOUBLE_XTREME,
+        "double_xtreme": ARENA_DOUBLE_XTREME,
         "combined": ARENA_COMBINED,
         "Combined": ARENA_COMBINED,
         "global": ARENA_COMBINED,

--- a/src/elo/beyblade_elo.py
+++ b/src/elo/beyblade_elo.py
@@ -125,9 +125,10 @@ ELO_VERSION = 3  # Version 3: Smooth K-factor, form adjustment, tanh margin mode
 # Arena constants
 ARENA_XTREME = "Xtreme"
 ARENA_DROP_ATTACK = "Drop Attack"
+ARENA_DOUBLE_XTREME = "Double Xtreme"
 ARENA_COMBINED = "Combined"  # Tracks all matches from all arenas
-SUPPORTED_ARENAS = [ARENA_XTREME, ARENA_DROP_ATTACK]
-ALL_ARENAS = [ARENA_XTREME, ARENA_DROP_ATTACK, ARENA_COMBINED]  # Including combined
+SUPPORTED_ARENAS = [ARENA_XTREME, ARENA_DROP_ATTACK, ARENA_DOUBLE_XTREME]
+ALL_ARENAS = [ARENA_XTREME, ARENA_DROP_ATTACK, ARENA_DOUBLE_XTREME, ARENA_COMBINED]  # Including combined
 
 # ------------ Arena normalization ------------
 
@@ -144,6 +145,10 @@ def normalize_arena_name(arena):
         "Drop Attack": ARENA_DROP_ATTACK,
         "DropAttack": ARENA_DROP_ATTACK,
         "drop_attack": ARENA_DROP_ATTACK,
+        "double xtreme": ARENA_DOUBLE_XTREME,
+        "Double Xtreme": ARENA_DOUBLE_XTREME,
+        "DoubleXtreme": ARENA_DOUBLE_XTREME,
+        "double_xtreme": ARENA_DOUBLE_XTREME,
         "combined": ARENA_COMBINED,
         "Combined": ARENA_COMBINED,
         "global": ARENA_COMBINED,


### PR DESCRIPTION
This PR will add the new "Double Xtreme" Stadium to the site, allowing users to use it in quick match as arena selection as well as accumulating own stadium stats and stadium ELO for it just as it is already happening with the `drop_attack` stadium.